### PR TITLE
fix: slider thumb aligning to slider's size

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ui_draw();
 
 ### DOCUMENTATION
 
-https://manuel-di-iorio.github.io/gmheadlessui
+https://headlessuigm.github.io/headlessui
 
 ### CONTRIBUTING
 

--- a/docs/docs/components/layer.md
+++ b/docs/docs/components/layer.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 10
+---
+
+# Layer
+
+A layer is a renderless component that handles the z-order of its children components. 
+
+It is used to understand which component is on top of another, by simply checking which one is the latest in the list.
+
+By default every component is a child of the root layer component, but you can also create other layers in order to have a better control of the inner ordering.
+
+### Example
+
+```js
+var myLayer = new UiLayerStep(0, 0, 500, 500);
+// Then use this new layer as parent of another component:
+new UiButton(0, 0, 100, 40, myLayer);
+```
+
+### Methods
+
+#### is_hovered(child_component)
+
+Check if the specified component is the most higher (on top) element, that is also intersecting the mouse
+
+| Param           | Description        | Type   | Default |
+|-----------------|--------------------|--------|---------|
+| child_component | Component to check | Struct |         |
+
+#### focus(child_component)
+
+Set the specified component as focused (if not already). Will bring the component on top
+
+| Param           | Description        | Type   | Default |
+|-----------------|--------------------|--------|---------|
+| child_component | Component to focus | Struct |         |

--- a/docs/docs/components/slider.md
+++ b/docs/docs/components/slider.md
@@ -25,17 +25,7 @@ with (slider.state) {
 | max_value    | Maximum selectable value                                                                | Real | 100                                  |
 | step         | Granularity of the slider. The step increment should be a divisor of the track's length | Real | 1                                    |
 | value        | Current selected value                                                                  | Real | 0                                    |
-| track_margin | The margin to apply to the start and the end of the slider track                        | Real | 0                                    |
-
-### Methods
-
-#### set_thumb_radius(radius)
-
- Set the thumb's radius
-
-| Param     | Description                  | Type  | Default |
-|-----------|------------------------------|-------|---------|
-| radius    | Radius of the slider's thumb | Real  |         |
+| thumb_radius |  Set the thumb's radius                                                                 | Real | 8                                    |
 
 ### Events
 

--- a/objects/oCtrl/Create_0.gml
+++ b/objects/oCtrl/Create_0.gml
@@ -1,3 +1,7 @@
+if (display_aa > 12) {
+	display_reset(8, false);
+}
+
 draw_debug = false;
 gui_width = display_get_gui_width();
 gui_height = display_get_gui_height();

--- a/scripts/scr_story_slider/scr_story_slider.gml
+++ b/scripts/scr_story_slider/scr_story_slider.gml
@@ -1,4 +1,6 @@
 function scr_story_slider(showcase) {
+	draw_set_circle_precision(64);
+	
 	var w = 200;
 	var h = 30;
 	var xx = showcase.x - round(w/2);
@@ -7,7 +9,9 @@ function scr_story_slider(showcase) {
 	var yy = showcase.y - round(h_full / 2);
 	
 	var slider0 = new UiSlider(xx, yy, w, h);
-	slider0.set_thumb_radius(10);
+	with (slider0.state) {
+		thumb_radius = 10;
+	}
 
 	yy += yoff;
 	var slider1 = new UiSlider(xx, yy, w, h);
@@ -17,9 +21,9 @@ function scr_story_slider(showcase) {
 
 	yy += yoff;
 	var slider2 = new UiSlider(xx, yy, w, h);
-	slider2.set_thumb_radius(5);
 	with (slider2.state) {
 		step = 25;
+		thumb_radius = 5;
 	}
 	
 	return [

--- a/scripts/ui_scrollbar_step/ui_scrollbar_step.gml
+++ b/scripts/ui_scrollbar_step/ui_scrollbar_step.gml
@@ -35,9 +35,9 @@ function UiScrollbarStep(_x, _y, _width, _height, _parent = undefined) : UiBaseC
 		var status = state.status;
 		var hovered = is_hovered();
 		
-		if (status != ui_enum_scrollbar_status.idle && mouse_check_button_released(mb_any)) {
+		if (status != ui_enum_scrollbar_status.idle && mouse_check_button_released(mb_left)) {
 			set({ status: ui_enum_scrollbar_status.idle });
-		} else if ((hovered && mouse_check_button_pressed(mb_any)) || state.status == ui_enum_scrollbar_status.dragging) {
+		} else if ((hovered && mouse_check_button_pressed(mb_left)) || state.status == ui_enum_scrollbar_status.dragging) {
 			// Update value if mouse pressed on scrollbar or if it is already being dragged
 			var mouse_delta = state.direction == ui_enum_scrollbar_direction.vertical
 				? global.ui_mouse_y - state.thumb_size / 2 - state.y

--- a/scripts/ui_slider_draw/ui_slider_draw.gml
+++ b/scripts/ui_slider_draw/ui_slider_draw.gml
@@ -12,13 +12,6 @@
 function UiSlider(_x, _y, _width, _height, _parent = undefined) : UiSliderStep(_x, _y, _width, _height, _parent) constructor {
 	with (state) {
 		/**
-		 * Thumb's circle radius
-		 * @internal
-		 * @see set_thumb_radius
-		 */
-		__thumb_radius = 8;
-		
-		/**
 		 * Track's thickness
 		 * This value will be assigned to the track's width or height based on
 		 * the slider's direction
@@ -26,20 +19,6 @@ function UiSlider(_x, _y, _width, _height, _parent = undefined) : UiSliderStep(_
 		track_thickness = 5;
 	}
 
-	/**
-	 * Set the thumb's radius
-	 * @param {Real} value the radius of the slider's thumb
-	 */
-	set_thumb_radius = function(value) {
-		with (state) {
-			__thumb_radius = value;
-			track_margin = value;
-		}
-	};
-	
-	// Initialize thumb radius
-	set_thumb_radius(state.__thumb_radius);
-    
 	draw = function() {
 	    var half_width = round(state.width / 2);
 	    var half_height = round(state.height / 2);
@@ -50,18 +29,18 @@ function UiSlider(_x, _y, _width, _height, _parent = undefined) : UiSliderStep(_
 		draw_set_color(bgcolor);
 		
 		if (state.direction == ui_enum_slider_direction.vertical) {
-		 	draw_rectangle(half_width - half_thickness, state.track_margin, half_width + half_thickness, state.height - state.track_margin, false);   
+		 	draw_rectangle(half_width - half_thickness, 0, half_width + half_thickness, state.height, false);
 		} else{
-	    	draw_rectangle(state.track_margin, half_height - half_thickness, state.width - state.track_margin, half_height + half_thickness, false);
+	    	draw_rectangle(0, half_height - half_thickness, state.width, half_height + half_thickness, false);
 		}
 		
 		// Draw the thumb
 		var thumb_x, thumb_y;
 		if (state.direction == ui_enum_slider_direction.vertical) {
 			thumb_x = half_width - 1;
-			thumb_y = (state.height - state.track_margin * 2) * ((state.value - state.min_value) / state.max_value) + state.track_margin;
+			thumb_y = (state.height - state.thumb_radius * 2) * ((state.value - state.min_value) / state.max_value) + state.thumb_radius;
 		} else {
-			thumb_x = (state.width - state.track_margin * 2) * ((state.value - state.min_value) / state.max_value) + state.track_margin;
+			thumb_x = (state.width - state.thumb_radius * 2) * ((state.value - state.min_value) / state.max_value) + state.thumb_radius;
 			thumb_y = half_height - 1;
 		}
 			
@@ -76,8 +55,8 @@ function UiSlider(_x, _y, _width, _height, _parent = undefined) : UiSliderStep(_
 		
 		draw_set_color(thumb_color);
 		draw_set_alpha(.5);
-		draw_circle(thumb_x, thumb_y, state.__thumb_radius, true);
+		draw_circle(thumb_x, thumb_y, state.thumb_radius, true);
 		draw_set_alpha(1);
-		draw_circle(thumb_x, thumb_y, state.__thumb_radius, false);
+		draw_circle(thumb_x, thumb_y, state.thumb_radius, false);
 	};
 }

--- a/scripts/ui_slider_step/ui_slider_step.gml
+++ b/scripts/ui_slider_step/ui_slider_step.gml
@@ -45,13 +45,11 @@ function UiSliderStep(_x, _y, _width, _height, _parent = undefined) : UiBaseComp
 	     * be a multiple of state.step
 	     */
 		value = 0;
-    
-	    /** The margin to apply to the start and the end of the slider track; 
-	     * useful when the thumb can overflow outside the track;
-	     * the actual track's length will be the component's size (width or height
-	     * bases on state.direction) minus this track margin
-	     */
-		track_margin = 0;
+		
+		/**
+		 * Thumb's radius
+		 */
+		thumb_radius = 8;
 	}
     
     step = function() {
@@ -63,16 +61,16 @@ function UiSliderStep(_x, _y, _width, _height, _parent = undefined) : UiBaseComp
 		} else if ((hovered && mouse_check_button_pressed(mb_left)) || state.status == ui_enum_slider_status.dragging) {
 			// Update value if mouse pressed on slider or if it is already being dragged
 			var mouse_delta = state.direction == ui_enum_slider_direction.vertical
-				? global.ui_mouse_y - state.y - state.track_margin
-				: global.ui_mouse_x - state.x - state.track_margin;
+				? global.ui_mouse_y - state.y - state.thumb_radius
+				: global.ui_mouse_x - state.x - state.thumb_radius;
 			var track_length = state.direction == ui_enum_slider_direction.vertical
-				? state.height - state.track_margin * 2
-				: state.width - state.track_margin * 2;
+				? state.height - state.thumb_radius * 2
+				: state.width - state.thumb_radius * 2;
 			var value = clamp(mouse_delta / track_length, 0, 1);
 			var stepped_value = round((state.max_value - state.min_value) * value / state.step) * state.step;
 			
-			set({ 
-				status: ui_enum_slider_status.dragging, 
+			set({
+				status: ui_enum_slider_status.dragging,
 				value: stepped_value,
 			});
 			


### PR DESCRIPTION
Note: there is one pixel on the left missing for the thumb, trying to understand the reason 

- few changes to AA and circle precision to improve the circle rendering (just for the test room)
- thumb_radius param in step function replacing track_margin
- brought back the layer in the docs, it is still useful as empty container until an actual Container component will be available